### PR TITLE
Make zpmhub compatible with both new and old version of zpm

### DIFF
--- a/src/ZPMHUB/Setup.cls
+++ b/src/ZPMHUB/Setup.cls
@@ -20,11 +20,22 @@ Property ServerName As %String;
 
 Property IsMonitoringEnabled As %Boolean;
 
+ClassMethod IsLegacy() As %Boolean [ CodeMode = expression ]
+{
+$SELECT(##class(%Dictionary.ClassDefinition).%ExistsId("%IPM.Main"): 0, ##class(%Dictionary.ClassDefinition).%ExistsId("%ZPM.PackageManager"): 1)
+}
+
 ClassMethod Setup(token As %String = "null", verbose As %Boolean = 0) As %Status
 {
-    if '##class(%Dictionary.ClassDefinition).%ExistsId("%ZPM.PackageManager") {
-        quit $$$ERROR($$$GeneralError,"You need to install ZPM Package Manager for ZpmHub to work")
-    } 
+    try {
+        set tIsLegacy = ..IsLegacy()
+    } catch ex {
+        If ex.Name = "<SELECT>" {
+            return $$$ERROR($$$GeneralError,"You need to install ZPM Package Manager for ZpmHub to work")
+        } else {
+            return ex.AsStatus()
+        }
+    }
     if ..%ExistsId($ZNspace) set Setup=..%OpenId($ZNspace)
     else  set Setup=..%New()
     set existingSetup=Setup
@@ -80,7 +91,11 @@ ClassMethod Setup(token As %String = "null", verbose As %Boolean = 0) As %Status
         $$$QuitOnError(..AddMonitorTask())
     }
     set repoCommand="repo -r -n registry -url "_Setup.Server_"/api/ -user ""Token"" -pass """_Setup.Token_""""
-    $$$QuitOnError(##class(%ZPM.PackageManager).Shell(repoCommand))
+    If tIsLegacy {
+        $$$QuitOnError(##class(%ZPM.PackageManager).Shell(repoCommand))
+    } else {
+        $$$QuitOnError(##class(%IPM.Main).Shell(repoCommand))
+    }
     $$$QuitOnError(Setup.%Save(0))
     $$$QuitOnError(##class(ZPMHUB.Task).SendSingleEnvironment($znspace))
     quit $$$OK
@@ -131,7 +146,11 @@ ClassMethod GetSSLConfiguration() As %String
 
 ClassMethod CheckEmail(server As %String, email As %String) As %Boolean
 {
-    set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    If ..IsLegacy() {
+        set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    } else {
+        set config=##class(%IPM.Repo.Remote.PackageService).%New()
+    }
     set location=server_"api/auth/checkEmail/"_email
     Set tRequest = config.GetHttpRequest(location)
     
@@ -143,7 +162,11 @@ ClassMethod CheckEmail(server As %String, email As %String) As %Boolean
 
 ClassMethod CheckToken(server As %String, token As %String) As %Numeric
 {
-    set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    If ..IsLegacy() {
+        set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    } else {
+        set config=##class(%IPM.Repo.Remote.PackageService).%New()
+    }
     set config.Location=server_"api/auth/check"
     set config.Username="token"
     set config.Password=token
@@ -156,7 +179,11 @@ ClassMethod CheckToken(server As %String, token As %String) As %Numeric
 
 ClassMethod GetToken(server As %String, email As %String, password As %String) As %String
 {
-    set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    If ..IsLegacy() {
+        set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    } else {
+        set config=##class(%IPM.Repo.Remote.PackageService).%New()
+    }
     set config.Location=server_"api/auth/token"
     set config.Username=$tr(email,"@","%")
     set config.Password=password
@@ -173,7 +200,11 @@ ClassMethod GetToken(server As %String, email As %String, password As %String) A
 
 ClassMethod Register(server As %String, email As %String, password As %String, name, orgName, org) As %Status
 {
-    set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    If ..IsLegacy() {
+        set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    } else {
+        set config=##class(%IPM.Repo.Remote.PackageService).%New()
+    }
     set config.Location=server_"api/auth/sign-up"
 
     Set tRequest = config.GetHttpRequest()

--- a/src/ZPMHUB/Task.cls
+++ b/src/ZPMHUB/Task.cls
@@ -11,6 +11,11 @@ Method OnTask() As %Status
   quit $$$OK
 }
 
+ClassMethod IsLegacy() As %Boolean [ CodeMode = expression ]
+{
+$SELECT(##class(%Dictionary.ClassDefinition).%ExistsId("%IPM.Main"): 0, ##class(%Dictionary.ClassDefinition).%ExistsId("%ZPM.PackageManager"): 1)
+}
+
 ClassMethod SendEnvironmentData()
 {
     set ns=""
@@ -29,15 +34,25 @@ ClassMethod SendSingleEnvironment(ns As %String) As %Status
     if '##class(%Dictionary.ClassDefinition).%ExistsId("ZPMHUB.Setup") {
         quit $$$ERROR($$$GeneralError,"ZpmHub class was removed from "+$namespace)
     }
-    if '##class(%Dictionary.ClassDefinition).%ExistsId("%ZPM.PackageManager") {
-        quit $$$ERROR($$$GeneralError,"You need to install ZPM Package Manager for ZpmHub to work")
+    Try {
+        set tIsLegacy = ..IsLegacy()
+    } catch ex {
+        If ex.Name = "<SELECT>" {
+            Return $$$ERROR($$$GeneralError,"You need to install ZPM Package Manager for ZpmHub to work")
+        } else {
+            Return ex.AsStatus()
+        }
     }
     set Setup=##class(ZPMHUB.Setup).%OpenId($Namespace)
     if 'Setup.IsMonitoringEnabled quit $$$OK
 
     set jsonData=..GetSingleEnvironmentData(ns)
 
-    set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    If tIsLegacy {
+        set config=##class(%ZPM.PackageManager.Client.REST.PackageManagerClient).%New()
+    } Else {
+        set config=##class(%IPM.Repo.Remote.PackageService).%New()
+    }
     set config.Location=Setup.Server_"api/environment/"
     set config.Username="token"
     set config.Password=Setup.Token
@@ -64,7 +79,11 @@ ClassMethod GetSingleEnvironmentData(ns As %String) As %Status
     set jsonResult.environmentName=Setup.EnvironmentName
     set jsonResult.serverName=Setup.ServerName
     set jsonResult.namespace=ns
-    $$$QuitOnError(##class(%ZPM.PackageManager).GetListModule(ns,.packageList,0))
+    If ..IsLegacy() {
+        $$$QuitOnError(##class(%ZPM.PackageManager).GetListModule(ns,.packageList,0))
+    } Else {
+        $$$QuitOnError(##class(%IPM.Main).GetListModule(ns,.packageList,0))
+    }
     set package="", jsonResult.packages=[]
     for {
         set package=$order(packageList(package))


### PR DESCRIPTION
Hi @bg-ssh 

## Background

InterSystems is planning to release a new version of IPM (previously known as ZPM). We made some breaking changes in this release, including renaming of packages and classes. Since your package references one or more of such renamed classes, we would like to help you update your package so that it's compatible with both new and old package managers.

## Testing

### Older Versions

You can test that this PR works on older versions (ZPM v0.7.1 and earlier) by running

```bash
zpm "load https://github.com/isc-shuliu/zpmhub"
```

### Newer Versions

You can also test the PR on our unreleased new package manager by running it in a container

```bash
git clone https://github.com/intersystems/ipm
cd ipm
git checkout v1
docker compose up -d
docker exec -it ipm-sandbox-1 /bin/bash
```

Then, in the docker container, run `iris session IRIS` to enter iris shell
```
do $System.OBJ.Load("/home/irisowner/zpm/preload/cls/IPM/Installer.cls", "ck")
do ##class(IPM.Installer).setup("/home/irisowner/zpm/")
zpm "repo -delete-all"
zpm "repo -reset-defaults"
```

Also, since the newer version of IPM is installed on a per-namespace level, you may want to enable package mapping if your code touches other namespaces.

Finally, you can run 

```
zpm "load https://github.com/isc-shuliu/zpmhub"
```

to verify successful installation. 



Let me know if you have any questions!